### PR TITLE
GELF timestamp should be Unix epoch

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 			hostname = "unknown"
 		}
 		packetEvent["host"] = hostname
-		packetEvent["timestamp"] = time.Now().UTC().String()
+		packetEvent["timestamp"] = int32(time.Now().Unix())
 		packetEvent["facility"] = *facility
 		packetEvent["short_message"] = packet.String()
 


### PR DESCRIPTION
GELF timestamp should be in Unix Epoch; see http://docs.graylog.org/en/3.0/pages/gelf.html