### PR TITLE
Rename protocol to ProtocolName; the former is already used

### DIFF
--- a/LayerHandler.go
+++ b/LayerHandler.go
@@ -65,7 +65,7 @@ func handleIPv6(event map[string]interface{}, layer gopacket.Layer) {
 }
 
 func handleTCP(event map[string]interface{}, layer gopacket.Layer) {
-	event["protocol"] = "TCP"
+	event["ProtocolName"] = "TCP"
 	tcp, _ := layer.(*layers.TCP)
 	tcpEvent := structs.Map(tcp)
 
@@ -87,7 +87,7 @@ func handleTCP(event map[string]interface{}, layer gopacket.Layer) {
 }
 
 func handleUDP(event map[string]interface{}, layer gopacket.Layer) {
-	event["protocol"] = "UDP"
+	event["ProtocolName"] = "UDP"
 	udp, _ := layer.(*layers.UDP)
 	udpEvent := structs.Map(udp)
 


### PR DESCRIPTION
This change allows TCP and UDP to be correctly processed by the GELF input.

Previously, the 'protocol' field was used by lower-level protocols, causing errors in graylog:
```
[136]: index [graylog2_1590], type [_doc], id [91994481-95ee-11ee-84f1-02ce55e8ca0b], message [ElasticsearchException[Elasticsearch exception [type=mapper_parsing_exception, reason=failed to parse field [protocol] of type [long] in document with id '91994481-95ee-11ee-84f1-02ce55e8ca0b'. Preview of field's value: 'TCP']]; nested: ElasticsearchException[Elasticsearch exception [type=illegal_argument_exception, reason=For input string: "TCP"]];]
```